### PR TITLE
Changed BigInt to BigInteger

### DIFF
--- a/pkcs11/java/src/org/opensc/pkcs11/wrap/PKCS11Certificate.java
+++ b/pkcs11/java/src/org/opensc/pkcs11/wrap/PKCS11Certificate.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 import javax.security.auth.x500.X500Principal;
 
-import sun.security.util.BigInt;
+import java.math.BigInteger;
 
 /**
  * This class manages X509 certificates stored on the card.
@@ -52,7 +52,7 @@ public class PKCS11Certificate extends PKCS11Object
 
     private X500Principal subject;
 	private X500Principal issuer;
-	private BigInt serial;
+	private BigInteger serial;
 	
 	/**
 	 * @param session The session to which we are associated.
@@ -72,7 +72,7 @@ public class PKCS11Certificate extends PKCS11Object
 		this.issuer = new X500Principal(raw_issuer); 
 		
 		byte[] raw_serial = getRawAttribute(PKCS11Attribute.CKA_SERIAL_NUMBER);
-		this.serial = new BigInt(raw_serial);
+		this.serial = new BigInteger(raw_serial);
 	}
 
 	/**
@@ -176,7 +176,7 @@ public class PKCS11Certificate extends PKCS11Object
 	/**
 	 * @return Returns the serial, which is the value of the CKA_SERIAL_NUMBER attribute.
 	 */
-	public BigInt getSerial()
+	public BigInteger getSerial()
 	{
 		return this.serial;
 	}


### PR DESCRIPTION
Replace sun.security.util.BigInt with java.math.BigInteger. This
approach uses the official Java API and standard package groups
that are guaranteed to be supported in the future.

Also, BigInt breaks when using OpenJDK.