### PR TITLE
Make PKCS15 platform independent

### DIFF
--- a/pkcs15/src/main/java/org/opensc/pkcs15/PKCS15CardException.java
+++ b/pkcs15/src/main/java/org/opensc/pkcs15/PKCS15CardException.java
@@ -1,0 +1,18 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.opensc.pkcs15;
+
+import javax.smartcardio.CardException;
+
+/**
+ *
+ * @author hfman
+ */
+public class PKCS15CardException extends PKCS15Exception{
+    public PKCS15CardException(String msg, CardException cause) {
+        super(msg, cause);
+    }
+}

--- a/pkcs15/src/main/java/org/opensc/pkcs15/PKCS15Exception.java
+++ b/pkcs15/src/main/java/org/opensc/pkcs15/PKCS15Exception.java
@@ -1,6 +1,6 @@
 /***********************************************************
  * $Id$
- * 
+ *
  * PKCS#15 cryptographic provider of the opensc project.
  * http://www.opensc-project.org
  *
@@ -17,14 +17,12 @@
  * limitations under the License.
  *
  * Created: 26.12.2007
- * 
+ *
  ***********************************************************/
 
 package org.opensc.pkcs15;
 
 import java.io.IOException;
-
-import javax.smartcardio.CardException;
 
 /**
  * @author wglas
@@ -33,7 +31,7 @@ import javax.smartcardio.CardException;
 public class PKCS15Exception extends IOException {
 
     private static final long serialVersionUID = 7500833559613739356L;
-    
+
     /**
      * This error code is for errors, which do originate from a
      * smart card operation.
@@ -44,17 +42,17 @@ public class PKCS15Exception extends IOException {
 
     public static final int ERROR_FILE_DEACTIVATED              = 0x6283;
     public static final int ERROR_FILE_TERMINATED               = 0x6285;
-    
+
     public static final int ERROR_AUTHENTICATION_FAILED         = 0x6300;
-    
+
     public static final int ERROR_EEPROM_ERROR                  = 0x6581;
-    
+
     public static final int ERROR_LC_INVALID                    = 0x6700;
-    
+
     public static final int ERROR_LOGICAL_CHANNEL_NOT_SUPPORTED = 0x6881;
     public static final int ERROR_SM_MODE_NOT_SUPPORTED         = 0x6882;
     public static final int ERROR_CHAINING_ERROR                = 0x6884;
-    
+
     public static final int ERROR_INVALID_COMMAND               = 0x6981;
     public static final int ERROR_ACCES_DENIED                  = 0x6982;
     public static final int ERROR_BS_OBJECT_BLOCKED             = 0x6983;
@@ -75,11 +73,11 @@ public class PKCS15Exception extends IOException {
     public static final int ERROR_DATA_OBJECT_NOT_FOUND         = 0x6A88;
     public static final int ERROR_FILE_EXISTS                   = 0x6A89;
     public static final int ERROR_DF_EXISTS                     = 0x6A8A;
-    
+
     public static final int ERROR_LE_INVALID                    = 0x6C00;
     public static final int ERROR_INS_INVALID                   = 0x6D00;
     public static final int ERROR_CLA_INVALID                   = 0x6E00;
-    
+
     public static final int ERROR_TECHNICAL_ERROR               = 0x6F00;
     public static final int ERROR_CHECKSUM                      = 0x6F81;
     public static final int ERROR_XRAM_OVERFLOW                 = 0x6F82;
@@ -90,11 +88,11 @@ public class PKCS15Exception extends IOException {
     public static final int ERROR_HARDWARE_MANIPULATION_DETECTED= 0x6F87;
     public static final int ERROR_TRANSACTION_BUFFER_OVERFLOW   = 0x6F88;
     public static final int ERROR_ASSERTION_FAILED              = 0x6FFF;
-    
+
     public static final int ERROR_INCREASE_DECREASE_EXCEEDED    = 0x9850;
 
     public static final int ERROR_TRANSPORT_ERROR = 0xFFFF;
-    
+
     private final int errorCode;
 
     /**
@@ -136,11 +134,11 @@ public class PKCS15Exception extends IOException {
     /**
      * Translate a CardException in to a PKCS15Excetion by setting the
      * error code to {@link #ERROR_TRANSPORT_ERROR}.
-     * 
+     *
      * @param msg The error message.
      * @param cause The card exception raised by the JAVA smartcard API.
      */
-    public PKCS15Exception(String msg, CardException cause) {
+    protected PKCS15Exception(String msg, Throwable cause) {
         super(msg,cause);
         this.errorCode = ERROR_TRANSPORT_ERROR;
     }


### PR DESCRIPTION
By replacing the signature of `public PKCS15Exception(String msg, CardException cause)` to `protected PKCS15Exception(String msg, Throwable cause)` and creating a new `PKCS15CardException` class the pkcs15-0.0.1-SNAPSHOT.jar file can also be used in Android because there no longer is a dependency on javax.smartcardio.CardException

CardOSToken.java now uses this new class for throwing card exceptions.